### PR TITLE
Docs: 전체 사용자 랭킹 쿼리문 수정

### DIFF
--- a/src/main/java/com/fours/tolevelup/repository/themeexp/ThemeExpRepository.java
+++ b/src/main/java/com/fours/tolevelup/repository/themeexp/ThemeExpRepository.java
@@ -39,7 +39,7 @@ public interface ThemeExpRepository extends JpaRepository<ThemeExp, String>, The
     @Query("select te.user from ThemeExp te group by te.user")
     Slice<User> findUserSortByUserId(Pageable pageable);
 
-    @Query(value = "SELECT RANK() OVER (ORDER BY SUM(:exp) DESC) FROM theme_exp WHERE user_id = :uid", nativeQuery = true)
-    int rank(@Param("exp") int exp, @Param("uid") String user_Id);
+    @Query(value = "SELECT i.ranking FROM(SELECT RANK() OVER (ORDER BY SUM(te.exp_total) DESC) ranking, te.user_id FROM theme_exp te GROUP BY te.user_id) i where i.user_id = :uid", nativeQuery = true)
+    int rank(@Param("uid") String user_Id);
 
 }

--- a/src/main/java/com/fours/tolevelup/service/user/UserServiceImpl.java
+++ b/src/main/java/com/fours/tolevelup/service/user/UserServiceImpl.java
@@ -170,10 +170,9 @@ public class UserServiceImpl implements UserService {
         Slice<UserDTO.publicUserData> userList = themeExpRepository.findUserSortByUserId(pageable).map(UserDTO.publicUserData::fromUser);
         List<RankDTO.RankData> rankList = new ArrayList<>();
         for(UserDTO.publicUserData user : userList){
-            int exp = themeExpRepository.expTotal(user.getUserId());
             rankList.add(RankDTO.RankData.builder().userData(user)
                     .exp_total(themeExpRepository.expTotal(user.getUserId()))
-                    .rank(themeExpRepository.rank(exp, user.getUserId()))
+                    .rank(themeExpRepository.rank(user.getUserId()))
                     .build());
         }
         return rankList;


### PR DESCRIPTION
- 사용자 전체의 랭킹을 나타내는 리스트 리턴
- 서브쿼리 인라인뷰 사용
![image](https://github.com/team-FourS/tolevelup-back-end/assets/126096318/2dcd7a89-43ca-4c81-8d95-d318de7cece0)
