### PR TITLE
Modify: feed 데이터에 좋아요/코멘트 관련 정보 추가

### DIFF
--- a/src/main/java/com/fours/tolevelup/controller/api/FeedController.java
+++ b/src/main/java/com/fours/tolevelup/controller/api/FeedController.java
@@ -26,7 +26,7 @@ public class FeedController {
     @GetMapping
     public Response<List<FeedResponse.FeedData>> feedList(Authentication authentication, Pageable pageable){
         return Response.success(
-                feedService.getFeedList(pageable)
+                feedService.getFeedList(authentication.getName(), pageable)
                         .stream().map(FeedResponse.FeedData::fromFeedDto)
                         .collect(Collectors.toList())
         );
@@ -41,12 +41,12 @@ public class FeedController {
         );
     }
 
-
+/*
     @GetMapping("/{userId}/likes")
     public Response<Long> likeCount(@PathVariable("userId")String userId){
         return Response.success(feedService.getFeedLikeCount(userId));
     }
-
+*/
     @GetMapping("/{user_id}/likes/{date}")
     public Response<Long> likeCount(@PathVariable("user_id")String userId,@PathVariable("date")Date date){
         return Response.success(feedService.getDateLikeCount(userId,date));

--- a/src/main/java/com/fours/tolevelup/controller/response/FeedResponse.java
+++ b/src/main/java/com/fours/tolevelup/controller/response/FeedResponse.java
@@ -23,10 +23,18 @@ public class FeedResponse {
     public static class FeedData{
         private UserDTO.publicUserData userData;
         private List<MissionDTO.mission> userCompleteMissions;
+        private boolean likeSent;
+        private long thisLikeCounts;
+        private boolean commentSent;
+        private long thisCommentCounts;
         public static FeedData fromFeedDto(FeedDTO.feedData feedData){
             return new FeedData(
                     feedData.getUserData(),
-                    feedData.getUserCompleteMissions()
+                    feedData.getUserCompleteMissions(),
+                    feedData.isMyLikeChecked(),
+                    feedData.getThisLikeCounts(),
+                    feedData.isMyCommentChecked(),
+                    feedData.getThisCommentCounts()
             );
         }
     }

--- a/src/main/java/com/fours/tolevelup/model/FeedDTO.java
+++ b/src/main/java/com/fours/tolevelup/model/FeedDTO.java
@@ -21,7 +21,10 @@ public class FeedDTO {
     public static class feedData{
         private UserDTO.publicUserData userData;
         private List<MissionDTO.mission> userCompleteMissions;
-
+        private boolean myLikeChecked;
+        private long thisLikeCounts;
+        private boolean myCommentChecked;
+        private long thisCommentCounts;
     }
 
 

--- a/src/main/java/com/fours/tolevelup/repository/CommentRepository.java
+++ b/src/main/java/com/fours/tolevelup/repository/CommentRepository.java
@@ -20,6 +20,12 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
 
     Optional<Comment> findById(Long id);
 
+    @Query("select c from Comment c where c.toUser.id =:to_uid and c.fromUser.id =:f_uid")
+    Optional<Comment> findByUserAndFeedUser(@Param("f_uid")String fromUser,@Param("to_uid")String feedUser);
+
+    @Query("select count(c) from Comment c where c.toUser.id =:uid and c.registeredAt >= current_date ")
+    Optional<Long> findByFeedUser(@Param("uid")String feedUserId);
+
     @Query("select c from Comment c where c.toUser =:user and c.registeredAt >= current_date order by c.registeredAt desc")
     Page<Comment> findByUser(@Param("user")User user, Pageable pageable);
 

--- a/src/main/java/com/fours/tolevelup/repository/LikeRepository.java
+++ b/src/main/java/com/fours/tolevelup/repository/LikeRepository.java
@@ -12,13 +12,14 @@ import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like,Long> {
 
-    @Query("select lk from Like lk where lk.fromUser = :f_user and lk.date = :date and lk.toUser = :t_user")
-    Optional<Like> findByUserAndDateAndToUser(@Param("f_user")User fromUser,@Param("date")Date date,@Param("t_user")User toUser);
+    @Query("select lk from Like lk where lk.fromUser = :f_user and lk.date = current_date and lk.toUser = :t_user")
+    Optional<Like> findByUserAndFeedUser(@Param("f_user")User fromUser,@Param("t_user")User toUser);
+
     @Query("select count(lk) from Like lk where lk.toUser = :user")
     long countAllByToUser(@Param("user")User user);
 
     @Query("select count(lk) from Like lk where lk.toUser = :user and lk.date >= current_date")
-    long countByToUser(@Param("user")User user);
+    Optional<Long> countByToUser(@Param("user")User user);
 
     @Query("select count(lk) from Like lk where lk.toUser =:user and lk.date =:date")
     long countByDateAndToUser(@Param("date")Date date,@Param("user")User user);


### PR DESCRIPTION
-로그인한 유저의 좋아요 전송 여부
-로그인한 유저의 코멘트 전송 여부
-해당 피드의 받은 총 좋아요 수
-해당 피드의 받은 총 코멘트 수

피드 불러오는 api 호출시 추가된 내용 확인
![image](https://github.com/team-FourS/tolevelup-back-end/assets/105481797/7c7ddc7f-c5d9-47f0-8919-ce1724594f5c)

