### PR TITLE
Fix: 코멘트 전송여부 판단하는 쿼리문 수정

### DIFF
--- a/src/main/java/com/fours/tolevelup/repository/CommentRepository.java
+++ b/src/main/java/com/fours/tolevelup/repository/CommentRepository.java
@@ -20,8 +20,9 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
 
     Optional<Comment> findById(Long id);
 
-    @Query("select c from Comment c where c.toUser.id =:to_uid and c.fromUser.id =:f_uid")
-    Optional<Comment> findByUserAndFeedUser(@Param("f_uid")String fromUser,@Param("to_uid")String feedUser);
+    @Query("select c from Comment c where c.toUser.id =:to_uid and c.fromUser.id =:f_uid " +
+            "and c.registeredAt >= current_date ")
+    Optional<Comment> findFirstByByUserAndFeedUser(@Param("f_uid")String fromUser,@Param("to_uid")String feedUser);
 
     @Query("select count(c) from Comment c where c.toUser.id =:uid and c.registeredAt >= current_date ")
     Optional<Long> findByFeedUser(@Param("uid")String feedUserId);

--- a/src/main/java/com/fours/tolevelup/service/FeedService.java
+++ b/src/main/java/com/fours/tolevelup/service/FeedService.java
@@ -80,7 +80,7 @@ public class FeedService {
     }
 
     private boolean getUserCommentChecked(String fromId, String toId){
-        return commentRepository.findByUserAndFeedUser(fromId,toId).isPresent();
+        return commentRepository.findFirstByByUserAndFeedUser(fromId,toId).isPresent();
     }
 
     @Transactional


### PR DESCRIPTION
보낸 comment가 여러개인 경우의 오류 수정

- registeredAt >=current_date 로 피드 날짜 판단
- findBy ->findFirstBy 여러 코멘트 보낸경우 첫번째 값만 가져오도록 설정